### PR TITLE
e2e subs

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,15 +1,35 @@
 const express = require('express')
 const http = require('http')
 const cors = require('cors')
+const {
+  SubscriptionServer,
+  ExecutionParams,
+  ConnectionContext
+} = require('subscriptions-transport-ws');
 
-const { VoyagerServer } = require('@aerogear/voyager-server')
-const { KeycloakSecurityService } = require('@aerogear/voyager-keycloak')
+const {
+  VoyagerServer
+} = require('@aerogear/voyager-server')
+const {
+  KeycloakSecurityService
+} = require('@aerogear/voyager-keycloak')
 const metrics = require('@aerogear/voyager-metrics')
 const auditLogger = require('@aerogear/voyager-audit')
-
+const {
+  makeExecutableSchema
+} = require('graphql-tools')
 const config = require('./config/config')
 const connect = require('./db')
-const { typeDefs, resolvers } = require('./schema')
+const {
+  typeDefs,
+  resolvers
+} = require('./schema')
+const {
+  execute,
+  subscribe,
+  GraphQLSchema
+} = require('graphql')
+
 
 let keycloakService = null
 
@@ -26,7 +46,9 @@ async function start() {
   const httpServer = http.createServer(app)
 
   app.use(cors())
-  metrics.applyMetricsMiddlewares(app, { path: '/metrics' })
+  metrics.applyMetricsMiddlewares(app, {
+    path: '/metrics'
+  })
 
   if (keycloakService) {
     keycloakService.applyAuthMiddleware(app)
@@ -44,7 +66,9 @@ async function start() {
     typeDefs,
     resolvers,
     playground: config.playgroundConfig,
-    context: async ({ req }) => {
+    context: async ({
+      req
+    }) => {
       // pass request + db ref into context for each resolver
       return {
         req: req,
@@ -61,11 +85,28 @@ async function start() {
 
   const apolloServer = VoyagerServer(apolloConfig, voyagerConfig)
 
-  apolloServer.applyMiddleware({ app })
-  apolloServer.installSubscriptionHandlers(httpServer)
 
-  httpServer.listen({ port: config.port }, () => {
+  apolloServer.applyMiddleware({
+    app
+  })
+  //apolloServer.installSubscriptionHandlers(httpServer)
+  httpServer.listen({
+    port: config.port
+  }, () => {
     console.log(`🚀  Server ready at http://localhost:${config.port}/graphql`)
+    // applySubscriptions(httpServer, {path: '/graphql'}, apolloServer.schema)
+    new SubscriptionServer({
+      execute,
+      subscribe,
+      onConnect: async connectionParams => {
+        console.log("ON SERVER TOKEN: ", connectionParams)
+        return await keycloakService.validateToken(connectionParams)
+      },
+      schema: apolloServer.schema
+    }, {
+      server: httpServer,
+      path: '/graphql'
+    });
   })
 }
 

--- a/server/src/schema.js
+++ b/server/src/schema.js
@@ -3,6 +3,10 @@ const { pubSub } = require('./subscriptions')
 const { conflictHandler } = require("@aerogear/voyager-conflicts")
 
 const typeDefs = gql `
+
+directive @hasRole(role: [String]) on FIELD | FIELD_DEFINITION
+
+
 type Task {
   id: ID!
   version: Int

--- a/src/app/services/sync/voyager.service.ts
+++ b/src/app/services/sync/voyager.service.ts
@@ -1,4 +1,5 @@
-import { createClient, VoyagerClient, DataSyncConfig, OfflineQueueListener, ConflictListener } from '@aerogear/voyager-client';
+import { createClient, VoyagerClient, DataSyncConfig,
+         OfflineQueueListener, ConflictListener, AuthContextProvider } from '@aerogear/voyager-client';
 import { Injectable } from '@angular/core';
 import { OpenShiftService } from '../openshift.service';
 import { AlertController } from '@ionic/angular';
@@ -65,14 +66,11 @@ export class VoyagerService {
     };
     if (!this.openShift.hasSyncConfig()) {
       // Use default localhost urls when OpenShift config is missing
-      console.log('config missing, using localhost');
       options.httpUrl = 'http://localhost:4000/graphql';
       options.wsUrl = 'ws://localhost:4000/graphql';
-    } else {
-      options.openShiftConfig = this.openShift.app.config;
     }
     if (this.auth.authService) {
-      options.headerProvider = this.auth.getAuth().getHeaderProvider();
+      options.authContextProvider = this.auth.getAuth().getAuthContextProvider() as AuthContextProvider;
     }
     this._apolloClient = await createClient(options);
   }


### PR DESCRIPTION
refactors the example server to use a subscription server without middleware. 
adds functionality to use this to the example app

Tests are never going to pass as its full e2e the sdk will need to be released too

### Verification:
1. Clone this and the two related PRs.
2. In the SDK with changes pulled:
```
npm run bootstrap
npm i
npm run build
npm link packages/sync
npm link packages/auth
```
3. From this repo:
`npm i && npm link @aerogear/auth && npm link @aerogear/voyager-client`
4. From the voyager-server repo with PR changes pulled:
```
npm run bootstrap
npm i
npm run compile
npm link packages/voyager-keycloak
```
5. From the server repo with PR changes pulled:
```
npm link @aerogear/voyager-keycloak
```
6. Lastly, add 2 configs for the client and server to mobile-services.json in the ionic app and config/keycloak.json in the server. Working examples can be found [for the client here:](https://gist.github.com/StephenCoady/5c28b060a5e162171ccc496c9ff6888d) and [for the server here:](https://gist.github.com/StephenCoady/fcdae95f697921efccf84be4c7863732)
7. From the ionic app and the server separately:
`npm run start`
8. Once you have logged in to the application check that all functionality is working as expected, i.e CRUD.
9. Next, open a second client in a different browser (or incognito) and log in again
10. Perform the same actions as previous and verify that subscriptions appear on both clients