### PR TITLE
fix:add textwrap to some labels to show full text

### DIFF
--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -44,26 +44,26 @@
     </ion-item>
     <ion-item routerDirection='root' routerLink="tasks">
       <ion-icon slot="start" color="medium" name="build"></ion-icon>
-      <ion-label>
+      <ion-label text-wrap>
         Manage Tasks
         <p>An example task manager to demonstrate how to perform data synchronisation with AeroGear Data Sync powered by Voyager GraphQL</p>
       </ion-label>
     </ion-item>
     <ion-item routerDirection='root' routerLink="profile">
       <ion-icon slot="start" color="medium" name="person"></ion-icon>
-      <ion-label>User profile
+      <ion-label text-wrap>User profile
         <p>An example to demonstrate how to perform user profile management with AeroGear Identity Management Service powered by Keycloak</p>
       </ion-label>
     </ion-item>
     <ion-item routerDirection='root' routerLink="files">
       <ion-icon slot="start" color="medium" name="document"></ion-icon>
-      <ion-label>Files
+      <ion-label text-wrap>Files
         <p>An example to demonstrate how to synchronise binary data with AeroGear Data Sync powered by Voyager GraphQL</p>
       </ion-label>
     </ion-item>
     <ion-item routerDirection='root' routerLink="security">
       <ion-icon slot="start" color="medium" name="settings"></ion-icon>
-      <ion-label>Device Security
+      <ion-label text-wrap>Device Security
         <p>An example to demonstrate security checks capabilities powered by Device Security SDK</p>
       </ion-label>
     </ion-item>


### PR DESCRIPTION
Add text wrap to labels on the home page to show full text
