### PR TITLE
fix: remove invalid docker command

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -7,7 +7,6 @@ COPY . .
 RUN npm install
 
 VOLUME ./files
-RUN chmod -Rf 777 ./files
 
 EXPOSE 4000
 CMD [ "npm", "start" ]


### PR DESCRIPTION
chmod is not required since we mounting volume. 
The volume itself will not support changing permissions.

