### PR TITLE
fix: Add explicit version for content creation

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -81,11 +81,9 @@ async function start() {
 
   const apolloServer = VoyagerServer(apolloConfig, voyagerConfig)
 
-
   apolloServer.applyMiddleware({
     app
   })
-  //apolloServer.installSubscriptionHandlers(httpServer)
   httpServer.listen({
     port: config.port
   }, () => {

--- a/server/src/tasks/schema.js
+++ b/server/src/tasks/schema.js
@@ -17,7 +17,7 @@ type Query {
 }
 
 type Mutation {
-  createTask(title: String!, description: String!, version: String!): Task
+  createTask(title: String!, description: String!): Task
   updateTask(id: ID!, title: String, description: String, version: Int!): Task
   deleteTask(id: ID!): ID
 }
@@ -48,6 +48,7 @@ const taskResolvers = {
       console.log("Create", args)
       const result = await context.db('tasks').insert({
         ...args,
+        version: 1
       }).returning('*').then((rows) => rows[0])
       // TODO context helper for publishing subscriptions in SDK?
       // TODO move from passing pushClient in context and use boolean to push or not here
@@ -103,13 +104,13 @@ function publish(actionType, data, pushClient) {
     },
       {
         criteria: {
-          alias: [ PUSH_ALIAS ]
+          alias: [PUSH_ALIAS]
         }
       }).then((response) => {
-      console.log("Notification sent, response received ", response);
-    }).catch((error) => {
-      console.log("Notification not sent, error received ", error)
-    })
+        console.log("Notification sent, response received ", response);
+      }).catch((error) => {
+        console.log("Notification not sent, error received ", error)
+      })
   }
   pubSub.publish(TASKS_SUBSCRIPTION_KEY, {
     tasks: {

--- a/server/src/tasks/schema.js
+++ b/server/src/tasks/schema.js
@@ -48,7 +48,6 @@ const taskResolvers = {
       console.log("Create", args)
       const result = await context.db('tasks').insert({
         ...args,
-        version: 1
       }).returning('*').then((rows) => rows[0])
       // TODO context helper for publishing subscriptions in SDK?
       // TODO move from passing pushClient in context and use boolean to push or not here

--- a/server/src/tasks/schema.js
+++ b/server/src/tasks/schema.js
@@ -17,7 +17,7 @@ type Query {
 }
 
 type Mutation {
-  createTask(title: String!, description: String!): Task
+  createTask(title: String!, description: String!, version: String!): Task
   updateTask(id: ID!, title: String, description: String, version: Int!): Task
   deleteTask(id: ID!): ID
 }

--- a/src/app/services/sync/graphql.queries.ts
+++ b/src/app/services/sync/graphql.queries.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 export const ADD_TASK = gql`
 mutation createTask($description: String!, $title: String!){
-    createTask(description: $description, title: $title){
+    createTask(description: $description, title: $title, version: $version){
       id
       title
       description

--- a/src/app/services/sync/graphql.queries.ts
+++ b/src/app/services/sync/graphql.queries.ts
@@ -2,7 +2,7 @@ import gql from 'graphql-tag';
 
 export const ADD_TASK = gql`
 mutation createTask($description: String!, $title: String!){
-    createTask(description: $description, title: $title, version: $version){
+    createTask(description: $description, title: $title){
       id
       title
       description

--- a/src/app/services/sync/item.service.ts
+++ b/src/app/services/sync/item.service.ts
@@ -106,14 +106,14 @@ export class ItemService {
   }
 
   // Local cache updates for CRUD operations
-  updateCacheOnAdd(cache, { data: { createTask } }) {
+  updateCacheOnAdd(cache, { data }) {
     let { allTasks } = cache.readQuery({ query: GET_TASKS });
     if (allTasks) {
-      if (!allTasks.find((task) => task.id === createTask.id)) {
-        allTasks.push(createTask);
+      if (!allTasks.find((task) => task.id === data.id)) {
+        allTasks.push(data);
       }
     } else {
-      allTasks = [createTask];
+      allTasks = [data];
     }
     cache.writeQuery({
       query: GET_TASKS,
@@ -123,13 +123,13 @@ export class ItemService {
     });
   }
 
-  updateCacheOnEdit(cache, { data: { updateTask } }) {
+  updateCacheOnEdit(cache, { data }) {
     const { allTasks } = cache.readQuery({ query: GET_TASKS });
     if (allTasks) {
       const index = allTasks.findIndex((task) => {
-        return updateTask.id === task.id;
+        return data.id === task.id;
       });
-      allTasks[index] = updateTask;
+      allTasks[index] = data;
     }
     cache.writeQuery({
       query: GET_TASKS,
@@ -139,13 +139,13 @@ export class ItemService {
     });
   }
 
-  updateCacheOnDelete(cache, { data: { deleteTask } }) {
+  updateCacheOnDelete(cache, { data }) {
     let deletedId;
-    if (deleteTask.optimisticResponse) {
+    if (data.optimisticResponse) {
       // Map optimistic response field
-      deletedId = deleteTask.id;
+      deletedId = data.id;
     } else {
-      deletedId = deleteTask;
+      deletedId = data;
     }
 
     const { allTasks } = cache.readQuery({ query: GET_TASKS });

--- a/src/app/services/sync/item.service.ts
+++ b/src/app/services/sync/item.service.ts
@@ -74,6 +74,7 @@ export class ItemService {
     const item = {
       'title': title,
       'description': description,
+      'version': 1
     };
     return this.apollo.mutate<Task>({
       mutation: ADD_TASK,

--- a/src/app/services/sync/item.service.ts
+++ b/src/app/services/sync/item.service.ts
@@ -107,6 +107,7 @@ export class ItemService {
 
   // Local cache updates for CRUD operations
   updateCacheOnAdd(cache, { data }) {
+    data = data.createTask;
     let { allTasks } = cache.readQuery({ query: GET_TASKS });
     if (allTasks) {
       if (!allTasks.find((task) => task.id === data.id)) {
@@ -124,6 +125,7 @@ export class ItemService {
   }
 
   updateCacheOnEdit(cache, { data }) {
+    data = data.updateTask;
     const { allTasks } = cache.readQuery({ query: GET_TASKS });
     if (allTasks) {
       const index = allTasks.findIndex((task) => {
@@ -140,6 +142,7 @@ export class ItemService {
   }
 
   updateCacheOnDelete(cache, { data }) {
+    data = data.deleteTask;
     let deletedId;
     if (data.optimisticResponse) {
       // Map optimistic response field


### PR DESCRIPTION
## Motivation

Fix compilation issues and lining problems for new JS-SDK after migration to apollo client 2.5. Add explicit version on creation in client. Using explicit version allows us to perform offline updates on the object. This idea is already extended by @StephenCoady in his PR for js-sdk

## Verification

PR can be verified by changing task offline 2 times and restoring connectivity.
After restoring connectivity no conflict should be seen. 
