### PR TITLE
fix: handle inability to create file upload directory

### DIFF
--- a/server/src/files/schema.js
+++ b/server/src/files/schema.js
@@ -23,7 +23,17 @@ const fileTypeDefs = `
 const PREFIX = 'files'
 const UPLOAD_DIR = `./${PREFIX}`
 // Ensure upload directory exists.
-mkdirp.sync(UPLOAD_DIR)
+
+try {
+  mkdirp.sync(UPLOAD_DIR)
+} catch (e) {
+  console.error(e)
+  console.error(`could not create directory for file uploads ${UPLOAD_DIR}`)
+  console.error(`file uploads will not work`)
+  console.error(`if running in OpenShift, you must create a persistent volume`)
+  console.error(`and mount it with read-write permissions to ${UPLOAD_DIR}`)
+}
+
 
 const storeFS = ({ stream, filename }) => {
   const id = shortid.generate()


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

This PR should allow the app to handle the case the file upload directory cannot be created. No changes are necessary to the actual file upload implementation itself right now because an error will already be thrown and returned to the client if the file upload fails.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
