### PR TITLE
fix: add volume to template

### DIFF
--- a/server/openshift-template.yml
+++ b/server/openshift-template.yml
@@ -252,6 +252,13 @@ objects:
           - containerPort: 4000
             protocol: TCP
           resources: {}
+          volumeMounts:
+          - mountPath: /usr/src/app/files
+            name: files-storage
+        volumes:
+        - name: files-storage
+          persistentVolumeClaim:
+            claimName: postgresql
     test: false
     triggers:
     - type: ConfigChange


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Added volume to OpenShift template for Ionic Showcase Server App.

### Why
File upload feature doesn't work without persistent storage mounted in server app

### To verify
```
oc new-project ionic-showcase-server-test
oc new-app -f server/openshift-template.yml
```
Check that there is no warning about missing persistent storage

This PR is related to fix in https://github.com/aerogear/ionic-showcase/pull/90