### PR TITLE
fix: clear apollo client cache and localstorage on logout

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -20,7 +20,7 @@ export class AuthService {
     constructor(private openShift: OpenShiftService, public platform: Platform, aerogear: VoyagerService) {
         if (this.isEnabled()) {
             this.auth = new Auth(this.openShift.getConfig());
-            this.aerogear = aerogear
+            this.aerogear = aerogear;
             this.initialized = platform.ready().then(() => {
                 const initOptions: KeycloakInitOptions = { onLoad: 'login-required' };
                 return this.auth.init(initOptions);
@@ -71,8 +71,8 @@ export class AuthService {
 
     logout() {
         if (this.isEnabled()) {
-            this.aerogear.apolloClient.clearStore()
-            this.aerogear.apolloClient.cache.reset()
+            this.aerogear.apolloClient.clearStore();
+            this.aerogear.apolloClient.cache.reset();
             window.localStorage.clear();
             return this.auth.logout();
         } else {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,6 +1,7 @@
 import { Auth } from '@aerogear/auth';
 import { Injectable } from '@angular/core';
 import { OpenShiftService } from './openshift.service';
+import { VoyagerService } from './sync/voyager.service';
 import { KeycloakInitOptions } from 'keycloak-js';
 import { AuthContextProvider } from '@aerogear/voyager-client';
 import { Platform } from '@ionic/angular';
@@ -14,10 +15,12 @@ import { Platform } from '@ionic/angular';
 export class AuthService {
     public auth: Auth | undefined;
     public initialized: Promise<boolean>;
+    private readonly aerogear: VoyagerService;
 
-    constructor(private openShift: OpenShiftService, public platform: Platform) {
+    constructor(private openShift: OpenShiftService, public platform: Platform, aerogear: VoyagerService) {
         if (this.isEnabled()) {
             this.auth = new Auth(this.openShift.getConfig());
+            this.aerogear = aerogear
             this.initialized = platform.ready().then(() => {
                 const initOptions: KeycloakInitOptions = { onLoad: 'login-required' };
                 return this.auth.init(initOptions);
@@ -68,6 +71,9 @@ export class AuthService {
 
     logout() {
         if (this.isEnabled()) {
+            this.aerogear.apolloClient.clearStore()
+            this.aerogear.apolloClient.cache.reset()
+            window.localStorage.clear();
             return this.auth.logout();
         } else {
             return Promise.reject('not enabled');

--- a/src/app/services/sync/voyager.service.ts
+++ b/src/app/services/sync/voyager.service.ts
@@ -2,7 +2,7 @@ import {
   createClient, VoyagerClient, DataSyncConfig,
   OfflineQueueListener, ConflictListener, AuthContextProvider
 } from '@aerogear/voyager-client';
-import { Injectable } from '@angular/core';
+import { Injectable, Injector } from '@angular/core';
 import { OpenShiftService } from '../openshift.service';
 import { AlertController } from '@ionic/angular';
 import { AuthService } from '../auth.service';
@@ -36,7 +36,7 @@ export class VoyagerService {
   private _apolloClient: VoyagerClient;
   private listener: OfflineQueueListener;
 
-  constructor(private openShift: OpenShiftService, public alertCtrl: AlertController, public auth: AuthService) {
+  constructor(private openShift: OpenShiftService, public alertCtrl: AlertController, public injector: Injector) {
   }
 
   set queueListener(listener: OfflineQueueListener) {
@@ -78,7 +78,7 @@ export class VoyagerService {
     } else {
       options.openShiftConfig = this.openShift.getConfig();
     }
-    options.authContextProvider = this.auth.getAuthContextProvider();
+    options.authContextProvider = this.injector.get(AuthService).auth.getAuthContextProvider()
     this._apolloClient = await createClient(options);
   }
 }

--- a/src/app/services/sync/voyager.service.ts
+++ b/src/app/services/sync/voyager.service.ts
@@ -69,7 +69,7 @@ export class VoyagerService {
       offlineQueueListener: numberOfOperationsProvider,
       conflictListener: new ConflictLogger(this.alertCtrl),
       fileUpload: true,
-      mutationCacheUpdates: mergedCacheUpdates
+      // mutationCacheUpdates: mergedCacheUpdates
     };
     if (!this.openShift.hasSyncConfig()) {
       // Use default localhost urls when OpenShift config is missing
@@ -78,7 +78,7 @@ export class VoyagerService {
     } else {
       options.openShiftConfig = this.openShift.getConfig();
     }
-    options.authContextProvider = this.injector.get(AuthService).auth.getAuthContextProvider()
+    options.authContextProvider = this.injector.get(AuthService).auth.getAuthContextProvider();
     this._apolloClient = await createClient(options);
   }
 }

--- a/src/app/services/sync/voyager.service.ts
+++ b/src/app/services/sync/voyager.service.ts
@@ -69,7 +69,7 @@ export class VoyagerService {
       offlineQueueListener: numberOfOperationsProvider,
       conflictListener: new ConflictLogger(this.alertCtrl),
       fileUpload: true,
-      // mutationCacheUpdates: mergedCacheUpdates
+      mutationCacheUpdates: mergedCacheUpdates
     };
     if (!this.openShift.hasSyncConfig()) {
       // Use default localhost urls when OpenShift config is missing


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

you can watch this video of the verification https://youtu.be/dH9V4o6aZb0

@wtrocki @StephenCoady @danielpassos @wei-lee I believe this fix is good enough. I'd love to know if I'm missing anything. Feel free to try verify with the following config from the community cluster

```
{
  "version": 1,
  "namespace": "demo",
  "clientId": "org.aerogear.ionic.showcase",
  "services": [
    {
      "id": "923e3416-45a3-11e9-9467-0af08791569c",
      "name": "keycloak",
      "type": "keycloak",
      "url": "https://keycloak-route-demo.comm2.skunkhenry.com/auth",
      "config": {
        "auth-server-url": "https://keycloak-route-demo.comm2.skunkhenry.com/auth",
        "confidential-port": 0,
        "public-client": true,
        "realm": "demo",
        "resource": "org.aerogear.ionic.showcase-public",
        "ssl-required": "external"
      }
    },
    {
      "id": "67dc6931-3f43-11e9-9467-0af08791569c",
      "name": "sync-app-showcase-server-org.aerogear.ionic.showcase",
      "type": "sync-app",
      "url": "https://sync-app-showcase-server-demo.comm2.skunkhenry.com/graphql",
      "config": {
        "websocketUrl": "wss://sync-app-showcase-server-demo.comm2.skunkhenry.com/graphql"
      }
    },
    {
      "id": "5f62de0e-3f42-11e9-9467-0af08791569c",
      "name": "ups",
      "type": "push",
      "url": "https://ups-demo.comm2.skunkhenry.com",
      "config": {
        "android": {
          "senderId": "881192658444",
          "variantId": "9f980b87-badc-4d0d-8923-65e8da0d50e1",
          "variantSecret": "5051c5e8-588b-4c48-b705-3f099c840411"
        }
      }
    }
  ]
}
```

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
