### PR TITLE
chore(deps): bump voyager client version

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@aerogear/cordova-plugin-aerogear-metrics": "2.3.1",
     "@aerogear/push": "2.3.1",
     "@aerogear/security": "2.3.1",
-    "@aerogear/voyager-client": "2.3.1",
+    "@aerogear/voyager-client": " 2.4.0-dev.1",
     "@angular/common": "7.2.9",
     "@angular/core": "7.2.9",
     "@angular/forms": "7.2.9",


### PR DESCRIPTION
### Description

Bump voyager client version from 2.3.1 --> 2.4.0-dev.1

##### Checklist

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
