### PR TITLE
fix: small layout and wording changes

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -26,12 +26,6 @@ export function loadUpdateItemPageModule() {
   return UpdateItemPageModule;
 }
 
-import { OfflineQueuePageModule } from './pages/offline-queue/offline-queue.module';
-
-export function loadOfflineQueuePageModule() {
-  return OfflineQueuePageModule;
-}
-
 const routes: Routes = [
   { path: '', redirectTo: 'home', pathMatch: 'full' },
   { path: 'home', loadChildren: loadHomePageModule },

--- a/src/app/pages/files/files.page.html
+++ b/src/app/pages/files/files.page.html
@@ -4,7 +4,7 @@
       <ion-menu-button></ion-menu-button>
     </ion-buttons>
     <ion-title>
-      File Management using Data Sync
+      File Management
     </ion-title>
   </ion-toolbar>
 </ion-header>

--- a/src/app/pages/offline-queue/offline-queue.page.html
+++ b/src/app/pages/offline-queue/offline-queue.page.html
@@ -4,13 +4,13 @@
       <ion-back-button defaultHref="tasks"></ion-back-button>
     </ion-buttons>
     <ion-title>
-      Offline Changes
+      Offline queue
     </ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content class="outer-content">
-  <ion-list *ngIf="stagedItems > 0">
+  <ion-list *ngIf="stagedItems">
     <ion-item-group
       *ngFor="let stagedItem of stagedItems; let last = last"
       [class.last-item]="last"

--- a/src/app/pages/offline-queue/offline-queue.page.html
+++ b/src/app/pages/offline-queue/offline-queue.page.html
@@ -4,13 +4,13 @@
       <ion-back-button defaultHref="tasks"></ion-back-button>
     </ion-buttons>
     <ion-title>
-      Offline queue
+      Offline Changes
     </ion-title>
   </ion-toolbar>
 </ion-header>
 
 <ion-content class="outer-content">
-  <ion-list *ngIf="stagedItems">
+  <ion-list *ngIf="stagedItems > 0">
     <ion-item-group
       *ngFor="let stagedItem of stagedItems; let last = last"
       [class.last-item]="last"

--- a/src/app/pages/settings/settings.page.html
+++ b/src/app/pages/settings/settings.page.html
@@ -20,14 +20,5 @@
         item-right
       ></ion-toggle>
     </ion-item>
-    <h4>Simulate offline in Task page</h4>
-    <ion-item>
-      <ion-label item-left>Enabled</ion-label>
-      <ion-toggle
-        [(ngModel)]="offlineToggleEnabled"
-        (ionChange)="toggleOfflineEnabled()"
-        item-right
-      ></ion-toggle>
-    </ion-item>
   </ion-list>
 </ion-content>

--- a/src/app/pages/task/task.page.html
+++ b/src/app/pages/task/task.page.html
@@ -15,7 +15,7 @@
 </ion-header>
 
 <ion-content class="outer-content">
-  <div *ngIf="items > 0">
+  <div *ngIf="items">
     <ion-list>
       <ion-item-group *ngFor="let item of items; let last = last" 
       [class.last-item]="last">

--- a/src/app/pages/task/task.page.html
+++ b/src/app/pages/task/task.page.html
@@ -15,7 +15,7 @@
 </ion-header>
 
 <ion-content class="outer-content">
-  <div *ngIf="items">
+  <div *ngIf="items > 0">
     <ion-list>
       <ion-item-group *ngFor="let item of items; let last = last" 
       [class.last-item]="last">
@@ -60,7 +60,6 @@
   <div>
     <ion-label>
       <ion-button
-        [disabled]="queue == 0"
         size="small"
         color="primary"
         fill="outline"
@@ -69,7 +68,7 @@
       >
         Offline changes
       </ion-button>
-      <ion-badge color="primary" class="offline-queue-badge" [class.network-badge-disabled]="queue == 0">{{
+      <ion-badge color="primary" class="offline-queue-badge">{{
         queue
       }}</ion-badge>
     </ion-label>

--- a/src/app/pages/task/task.page.scss
+++ b/src/app/pages/task/task.page.scss
@@ -52,8 +52,4 @@ ion-footer div {
 .offline-queue-badge {
   margin-left: -7px;
   vertical-align: top;
-
-  &.network-badge-disabled {
-    --ion-color-base: #acbafe !important;
-  }
 }


### PR DESCRIPTION
### Description

- Removed disabled state of Offline Changes button
- Removed white space on Task and Queue pages if there are no items
- Changed File Management title
- Removed unnecessary section from Settings page
- Removed redundant routing 

![localhost_8100_tasks (5)](https://user-images.githubusercontent.com/24867345/55009560-aa4abb80-4fda-11e9-9acc-5197c3237745.png)

![localhost_8100_tasks (4)](https://user-images.githubusercontent.com/24867345/55009561-aa4abb80-4fda-11e9-9d32-aa5590a4f5b6.png)
