### PR TITLE
Fix: empty list UI issue for MD

### DIFF
--- a/src/app/pages/offline-queue/offline-queue.page.html
+++ b/src/app/pages/offline-queue/offline-queue.page.html
@@ -11,10 +11,8 @@
 
 <ion-content class="outer-content">
   <ion-list *ngIf="stagedItems">
-    <ion-item-group
-      *ngFor="let stagedItem of stagedItems; let last = last"
-      [class.last-item]="last"
-    >
+    <ion-item-group *ngFor="let stagedItem of stagedItems; let first = first; let last = last" [class.last-item]="last"
+      [class.first-item]="first">
       <ion-item>
         <ion-label>
           <h2>

--- a/src/app/pages/offline-queue/offline-queue.page.html
+++ b/src/app/pages/offline-queue/offline-queue.page.html
@@ -41,4 +41,15 @@
       </ion-item>
     </ion-item-group>
   </ion-list>
+
+  <ion-grid class="queue-empty ion-justify-content-center" *ngIf="!stagedItems || stagedItems.length == 0">
+    <ion-row class="ion-justify-content-center">
+      <ion-col>
+        <ion-text color="medium">
+          <p>You currently have no changes<br /> staged offline.</p>
+        </ion-text>
+      </ion-col>
+    </ion-row>
+  </ion-grid>
+
 </ion-content>

--- a/src/app/pages/offline-queue/offline-queue.page.scss
+++ b/src/app/pages/offline-queue/offline-queue.page.scss
@@ -2,6 +2,10 @@
     padding-bottom: 0;
 }
 
+.list-md {
+    padding: 0;
+}
+
 .item .sc-ion-label-md-h {
     overflow: visible;
     white-space: pre-wrap;

--- a/src/app/pages/offline-queue/offline-queue.page.scss
+++ b/src/app/pages/offline-queue/offline-queue.page.scss
@@ -22,3 +22,14 @@ ion-badge {
     white-space: pre-line;
     text-align: left;
 }
+
+.queue-empty {
+    height: 100%;
+    display: flex;
+    align-items: center;
+    text-align: center;
+
+    p {
+        line-height: 150%
+    }
+}

--- a/src/app/pages/task/task.page.html
+++ b/src/app/pages/task/task.page.html
@@ -17,8 +17,8 @@
 <ion-content class="outer-content">
   <div *ngIf="items">
     <ion-list>
-      <ion-item-group *ngFor="let item of items; let last = last" 
-      [class.last-item]="last">
+      <ion-item-group *ngFor="let item of items; let first = first; let last = last" [class.first-item]="first"
+        [class.last-item]="last">
         <ion-item>
           <ion-label>
             <h2>{{ item.title }}</h2>
@@ -28,26 +28,13 @@
             <br />
             <ion-note>
               <ion-badge color="primary">
-                Server version: {{ item.version }}</ion-badge
-              >
+                Server version: {{ item.version }}</ion-badge>
             </ion-note>
           </ion-label>
-          <ion-button
-            item-start
-            class="create-button"
-            color="primary"
-            fill="outline"
-            (click)="goToItem(item)"
-          >
+          <ion-button item-start class="create-button" color="primary" fill="outline" (click)="goToItem(item)">
             <ion-icon name="create"></ion-icon>
           </ion-button>
-          <ion-button
-            item-end
-            class="trash-button"
-            color="primary"
-            fill="outline"
-            (click)="deleteItem(item)"
-          >
+          <ion-button item-end class="trash-button" color="primary" fill="outline" (click)="deleteItem(item)">
             <ion-icon name="trash"></ion-icon>
           </ion-button>
         </ion-item>
@@ -59,24 +46,14 @@
 <ion-footer>
   <div>
     <ion-label>
-      <ion-button
-        size="small"
-        color="primary"
-        fill="outline"
-        routerLink="/offline-queue"
-        class="offline-queue-button"
-      >
+      <ion-button size="small" color="primary" fill="outline" routerLink="/offline-queue" class="offline-queue-button">
         Offline changes
       </ion-button>
       <ion-badge color="primary" class="offline-queue-badge">{{
         queue
       }}</ion-badge>
     </ion-label>
-    <ion-badge class="network-badge" color="secondary" *ngIf="online"
-      >Online</ion-badge
-    >
-    <ion-badge class="network-badge" color="primary" *ngIf="!online"
-      >Offline</ion-badge
-    >
+    <ion-badge class="network-badge" color="secondary" *ngIf="online">Online</ion-badge>
+    <ion-badge class="network-badge" color="primary" *ngIf="!online">Offline</ion-badge>
   </div>
 </ion-footer>

--- a/src/app/pages/task/task.page.scss
+++ b/src/app/pages/task/task.page.scss
@@ -1,8 +1,12 @@
+.list-md {
+  padding: 0;
+}
+
 .task-item {
   padding-bottom: 0;
 }
 
-.item .sc-ion-label-md-h {
+.item ion-label {
   overflow: visible;
   white-space: pre-wrap;
 }

--- a/src/global.scss
+++ b/src/global.scss
@@ -19,7 +19,12 @@ ion-item {
     --padding-end: 16px;
 }
 
+.first-item {
+    padding-top: 8px;
+}
+
 .last-item {
+    padding-bottom: 8px;
     ion-item {
         --border-color: transparent;
     }


### PR DESCRIPTION
### Description

Unnecessary white strip showing for empty `ion-list` on Task and Offline Queue pages.

Before:
![localhost_8100_tasks(Pixel 2) (4)](https://user-images.githubusercontent.com/24867345/55553154-570df280-56d7-11e9-8649-0f2297e7ad93.png)
![localhost_8100_offline-queue(Pixel 2)](https://user-images.githubusercontent.com/24867345/55553161-60975a80-56d7-11e9-859f-69cc963b5bb1.png)

After:
![localhost_8100_tasks(Pixel 2) (6)](https://user-images.githubusercontent.com/24867345/55553172-68ef9580-56d7-11e9-8703-afdb11f18e0b.png)
![localhost_8100_offline-queue(Pixel 2) (1)](https://user-images.githubusercontent.com/24867345/55562620-3e5c0780-56ec-11e9-9855-383940a1a5d6.png)

