### PR TITLE
fix: menu and home UI

### DIFF
--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -7,7 +7,7 @@
         </ion-toolbar>
       </ion-header>
       <ion-content>
-        <ion-list>
+        <ion-list class="menu">
           <ion-item no-lines>
             <ion-avatar item-start class="banner">
               <img src="./assets/aerogear.png">
@@ -54,7 +54,7 @@
           </ion-menu-toggle>
           <ion-menu-toggle auto-hide="false">
             <ion-item routerDirection='root' routerLink="/security">
-              <ion-icon slot="start" name="settings"></ion-icon>
+              <ion-icon slot="start" name="warning"></ion-icon>
               <ion-label>
                 Device Security
               </ion-label>

--- a/src/app/pages/home/home.page.html
+++ b/src/app/pages/home/home.page.html
@@ -50,7 +50,7 @@
       </ion-label>
     </ion-item>
     <ion-item routerDirection="root" routerLink="security">
-      <ion-icon slot="start" color="medium" name="settings"></ion-icon>
+      <ion-icon slot="start" color="medium" name="warning"></ion-icon>
       <ion-label text-wrap>Device Security
         <p>
           An example to demonstrate security checks capabilities powered by

--- a/src/global.scss
+++ b/src/global.scss
@@ -19,6 +19,12 @@ ion-item {
     --padding-end: 16px;
 }
 
+.menu {
+    ion-item {
+        --padding-end: 0;
+    }
+}
+
 .last-item {
     ion-item {
         --border-color: transparent;


### PR DESCRIPTION
### Description

- Separate icons for Device Security and Settings
- Border bottom of menu to reach edge

Before: 

![localhost_8100_ (2)](https://user-images.githubusercontent.com/24867345/55616722-5da97200-578a-11e9-88b0-10407f3cde0d.png)
![localhost_8100_ (3)](https://user-images.githubusercontent.com/24867345/55616724-5da97200-578a-11e9-8c5b-b21564dd2f74.png)

After:

![localhost_8100_ (1)](https://user-images.githubusercontent.com/24867345/55616736-6732da00-578a-11e9-962b-65d35aae8770.png)
![localhost_8100_](https://user-images.githubusercontent.com/24867345/55616738-6732da00-578a-11e9-82ae-536cafccc79c.png)
