### PR TITLE
feat: tools to simplify local keycloak setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@ $RECYCLE.BIN/
 Thumbs.db
 UserInterfaceState.xcuserstate
 package-lock.json 
-src/mobile-services.js
+src/mobile-services.json
 server/src/config/keycloak.json

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ Thumbs.db
 UserInterfaceState.xcuserstate
 package-lock.json 
 src/mobile-services.js
+server/src/config/keycloak.json

--- a/README.adoc
+++ b/README.adoc
@@ -57,13 +57,6 @@ export NODE_TLS_REJECT_UNAUTHORIZED=0
 
 Follow these instructions to set up Keycloak for Authentication/Authorization.
 
-. Start the the Postgres database and the MQTT broker
-+
-```shell
-cd ./server
-docker-compose up
-```
-
 . Start Keycloak Server
 +
 ```shell

--- a/README.adoc
+++ b/README.adoc
@@ -9,6 +9,8 @@ Implementation includes:
 - Integration with AeroGear Mobile Services
 - Ionic 4 Angular frontend backed by Cordova
 - A Node.js GraphQL Server that implements a sample `Tasks` workflow
+- Authentication provided by Keycloak integration on the server and client side
+- GraphQL Subscriptions backed by an MQTT broker
 
 === GraphQL Client
 
@@ -28,11 +30,11 @@ Requirements:
 
 === Running the server
 
-. Start the PostgreSQL container
+. Start the Postgres database and the MQTT broker
 +
 ```shell
 cd ./server
-docker-compose up -d
+docker-compose up
 ```
 
 . Start the server
@@ -50,6 +52,39 @@ If Keycloak integration is enabled on the server, and the Keycloak server is run
 export NODE_TLS_REJECT_UNAUTHORIZED=0
 ```
 ====
+
+=== Running the Server with the Keycloak Integration
+
+Follow these instructions to set up Keycloak for Authentication/Authorization.
+
+. Start the the Postgres database and the MQTT broker
++
+```shell
+cd ./server
+docker-compose up
+```
+
+. Start Keycloak Server
++
+```shell
+npm run keycloak
+```
+
+. Configure the Keycloak Server
++
+```shell
+npm run keycloak:init
+```
+
+This command creates the necessary resources in Keycloak and prints instructions *you must follow to enable the integration.* 
+
+Follow the instructions and copy the JSON configurations to the appropriate location.
+The showcase app and server will read these configurations and the integration will be enabled when they are started.
+
+By default, two users that can log into the application are created.
+
+- username: `developer`, password: `developer`
+- username: `admin`, password: `admin`
 
 === Running the Server on OpenShift 
 

--- a/server/package.json
+++ b/server/package.json
@@ -5,7 +5,9 @@
   "main": "src/index.js",
   "scripts": {
     "start": "nodemon src/index.js",
-    "push": "docker build . -t aerogear/voyager-server-example-task && docker push aerogear/voyager-server-example-task"
+    "push": "docker build . -t aerogear/voyager-server-example-task && docker push aerogear/voyager-server-example-task",
+    "keycloak": "docker-compose -f ./scripts/keycloak/docker-compose.yml up",
+    "keycloak:init": "node ./scripts/keycloak/initKeycloak.js"
   },
   "license": "Apache 2.0",
   "dependencies": {

--- a/server/scripts/keycloak/docker-compose.yml
+++ b/server/scripts/keycloak/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3'
+
+services:
+  keycloak:
+    image: jboss/keycloak:3.4.3.Final
+    ports:
+      - "8080:8080"
+    environment:
+      DB_VENDOR: h2
+      KEYCLOAK_USER: admin
+      KEYCLOAK_PASSWORD: admin

--- a/server/scripts/keycloak/initKeycloak.js
+++ b/server/scripts/keycloak/initKeycloak.js
@@ -1,0 +1,325 @@
+/**
+ * This script helps set up a local keycloak environment
+ * It assumes keycloak is already running and available at
+ * http://localhost:8080
+ * It does the following:
+ * * Imports a new realm located in ./realm-export.json. This realm has two clients
+ *   * voyager-testing-public - public client used by the mobile application
+ *   * voyager-testing-bearer - bearer client used by the server to authenticate requests
+ * * Creates the realm roles and client roles defined in the realmRoleNames and clientRoleNames lists
+ * * Creates the users defined in the users list
+ * * Assigns the client and realm roles to the users
+ */
+
+const axios = require('axios')
+const realmToImport = require('./realm-export.json')
+
+// the keycloak server we're working against
+const KEYCLOAK_URL = 'http://localhost:8080/auth'
+
+// name of the realm
+const APP_REALM = 'voyager-testing'
+
+// name of the admin realm
+const ADMIN_REALM = 'master'
+
+const RESOURCE = 'admin-cli'
+const ADMIN_USERNAME = 'admin'
+const ADMIN_PASSWORD = 'admin'
+let token = ''
+
+// The keycloak client used by the showcase app
+const PUBLIC_CLIENT_NAME = 'voyager-testing-public'
+const BEARER_CLIENT_NAME = 'voyager-testing-bearer'
+let PUBLIC_CLIENT
+
+// The client roles you want created for the PUBLIC_CLIENT_NAME client
+const clientRoleNames = [
+  'admin',
+  'developer'
+]
+
+// The realm roles we want for the realm
+const realmRoleNames = [
+  'admin',
+  'developer'
+]
+
+let realmRoles
+let clientRoles
+
+// The users we want to create
+const users = [
+  {
+    name: 'admin',
+    password: 'admin',
+    realmRoles: [
+      'admin'
+    ],
+    clientRoles: [
+      'admin'
+    ]
+  },
+  {
+    name: 'developer',
+    password: 'developer',
+    realmRoles: [
+      'developer'
+    ],
+    clientRoles: [
+      'developer'
+    ]
+  }
+]
+
+// This is called by an immediately invoked function expression
+// at the bottom of the file
+async function prepareKeycloak () {
+  try {
+    console.log('Authenticating with keycloak server')
+    token = await authenticateKeycloak()
+
+    // Always do a hard reset first just to keep things tidy
+    console.log('Going to reset keycloak')
+    await resetKeycloakConfiguration()
+
+    console.log('Importing sample realm into keycloak')
+    await importRealm()
+
+    console.log('Fetching available clients from keycloak')
+    const clients = await getClients()
+
+    // Get the public client object from keycloak
+    // Need this for the ID assigned by keycloak
+    PUBLIC_CLIENT = clients.find((client) => client.clientId === PUBLIC_CLIENT_NAME)
+    BEARER_CLIENT = clients.find((client) => client.clientId === BEARER_CLIENT_NAME)
+
+    console.log('creating client roles')
+    for (let roleName of clientRoleNames) {
+      await createClientRole(PUBLIC_CLIENT, roleName)
+    }
+
+    console.log('creating realm roles')
+    for (let roleName of realmRoleNames) {
+      await createRealmRole(roleName)
+    }
+
+    // get the actual role objects from keycloak after creating them
+    // need to get the ids that were created on them
+    realmRoles = await getRealmRoles()
+    clientRoles = await getClientRoles(PUBLIC_CLIENT)
+
+    for (let user of users) {
+      // Create a new user
+      console.log(`creating user ${user.name} with password ${user.password}`)
+      const userIdUrl = await createUser(user.name, user.password)
+      
+      // Assign roles to the user
+      await assignRealmRolesToUser(user, userIdUrl)
+      await assignClientRolesToUser(user, PUBLIC_CLIENT, userIdUrl)
+    }
+
+    const bearerInstallation = await getClientInstallation(BEARER_CLIENT)
+    const publicInstallation = await getClientInstallation(PUBLIC_CLIENT)
+
+    console.log()
+    console.log('Your keycloak server is set up for local usage and development')
+    console.log('1. Copy the following server config into ionic-showcase/server/src/config/keycloak.json')
+    console.log()
+    console.log(JSON.stringify(bearerInstallation, null, 2))
+    console.log()
+    console.log('2. Copy the following app config into the services array in ionic-showcase/src/mobile-services.json')
+    console.log(JSON.stringify(getMobileServicesConfig(publicInstallation), null, 2))
+    console.log('Done. Please follow the instructions printed above to ensure your environment is set up properly.')
+  } catch(e) {
+    console.error(e)
+    process.exit(1)
+  }
+}
+
+async function getClientInstallation(client, installationType = 'keycloak-oidc-keycloak-json') {
+  if (client) {
+    const res = await axios({
+      method: 'GET',
+      url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/clients/${client.id}/installation/providers/${installationType}`,
+      headers: { 'Authorization': token }
+    })
+    return res.data
+  }
+  throw new Error('client is undefined')
+}
+
+async function assignRealmRolesToUser(user, userIdUrl) {
+  for (let roleToAssign of user.realmRoles) {
+    console.log(`Assigning realm role ${roleToAssign} to user ${user.name}`)
+    const selectedRealmRole = realmRoles.find(role => role.name === roleToAssign)
+
+    if (selectedRealmRole) {
+      await assignRealmRoleToUser(userIdUrl, selectedRealmRole)
+    } else {
+      console.error(`realm role ${roleToAssign} does not exist`)
+    }
+  }
+}
+
+async function assignClientRolesToUser(user, client, userIdUrl) {
+  for (let roleToAssign of user.clientRoles) {
+    console.log(`assigning client role ${roleToAssign} from client ${PUBLIC_CLIENT_NAME} on user ${user.name}`)
+    const selectedClientRole = clientRoles.find(clientRole => clientRole.name === roleToAssign)
+    if (selectedClientRole) {
+      await assignClientRoleToUser(userIdUrl, client, selectedClientRole)
+    } else {
+      console.error(`client role ${roleToAssign} does not exist on client ${PUBLIC_CLIENT_NAME}`)
+    }
+  }
+}
+
+async function authenticateKeycloak () {
+  const res = await axios({
+    method: 'POST',
+    url: `${KEYCLOAK_URL}/realms/${ADMIN_REALM}/protocol/openid-connect/token`,
+    data: `client_id=${RESOURCE}&username=${ADMIN_USERNAME}&password=${ADMIN_PASSWORD}&grant_type=password`
+  })
+  return `Bearer ${res.data['access_token']}`
+}
+
+async function importRealm () {
+  return await axios({
+    method: 'POST',
+    url: `${KEYCLOAK_URL}/admin/realms`,
+    data: realmToImport,
+    headers: { 'Authorization': token, 'Content-Type': 'application/json' }
+  })
+}
+
+async function getRealmRoles () {
+  const res = await axios({
+    method: 'GET',
+    url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/roles`,
+    headers: { 'Authorization': token }
+  })
+  return res.data
+}
+
+async function createClientRole (client, roleName) {
+  try {
+    return await axios({
+      method: 'POST',
+      url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/clients/${client.id}/roles`,
+      headers: { 'Authorization': token },
+      data: {
+        clientRole: true,
+        name: roleName
+      }
+    })
+  } catch (e) {
+    if (e.response.data.errorMessage === `Role with name ${roleName} already exists`) {
+      console.log(e.response.data.errorMessage)
+    } else {
+      throw (e)
+    }
+  }
+}
+
+async function createRealmRole(roleName) {
+  try {
+    return await axios({
+      method: 'POST',
+      url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/roles`,
+      headers: { 'Authorization': token },
+      data: {
+        clientRole: false,
+        name: roleName
+      }
+    })
+  } catch (e) {
+    if (e.response.data.errorMessage === `Role with name ${roleName} already exists`) {
+      console.log(e.response.data.errorMessage)
+    } else {
+      throw (e)
+    }
+  }
+}
+
+async function getClients () {
+  const res = await axios({
+    method: 'GET',
+    url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/clients`,
+    headers: { 'Authorization': token }
+  })
+  return res.data
+}
+
+async function getClientRoles (client) {
+  const res = await axios({
+    method: 'GET',
+    url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/clients/${client.id}/roles`,
+    headers: { 'Authorization': token }
+  })
+  return res.data
+}
+
+async function createUser (name, password) {
+  const res = await axios({
+    method: 'post',
+    url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}/users`,
+    data: {
+      'username': name,
+      'credentials': [{ 'type': 'password', 'value': password, 'temporary': false }],
+      'enabled': true
+    },
+    headers: { 'Authorization': token, 'Content-Type': 'application/json' }
+  })
+  if (res) {
+    return res.headers.location
+  }
+}
+
+async function assignRealmRoleToUser (userIdUrl, role) {
+  const res = await axios({
+    method: 'POST',
+    url: `${userIdUrl}/role-mappings/realm`,
+    data: [role],
+    headers: { 'Authorization': token, 'Content-Type': 'application/json' }
+  })
+  return res.data
+}
+
+async function assignClientRoleToUser (userIdUrl, client, role) {
+  const res = await axios({
+    method: 'POST',
+    url: `${userIdUrl}/role-mappings/clients/${client.id}`,
+    data: [role],
+    headers: { 'Authorization': token, 'Content-Type': 'application/json' }
+  })
+  return res.data
+}
+
+async function resetKeycloakConfiguration () {
+  try {
+    await axios({
+      method: 'DELETE',
+      url: `${KEYCLOAK_URL}/admin/realms/${APP_REALM}`,
+      headers: { 'Authorization': token }
+    })
+  } catch(e) {
+    if (e.response.status !== 404) {
+      throw e
+    }
+    console.log(`404 while deleting realm ${APP_REALM} - ignoring`)
+  }
+}
+
+function getMobileServicesConfig(installationConfig) {
+  return {
+    id: 'some-id',
+    name: 'keycloak',
+    type: 'keycloak',
+    url: KEYCLOAK_URL,
+    config: installationConfig
+  }
+}
+
+(async () => {
+  await prepareKeycloak()
+})()

--- a/server/scripts/keycloak/realm-export.json
+++ b/server/scripts/keycloak/realm-export.json
@@ -1,0 +1,1856 @@
+{
+  "id": "voyager-testing",
+  "realm": "voyager-testing",
+  "notBefore": 0,
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 604800,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "offlineSessionIdleTimeout": 2592000,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "enabled": true,
+  "sslRequired": "none",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": true,
+  "editUsernameAllowed": true,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "5652e1c8-ffa1-4c61-84e4-de09e3549faa",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "scopeParamRequired": true,
+        "composite": false,
+        "clientRole": false,
+        "containerId": "voyager-testing"
+      },
+      {
+        "id": "9d966482-180a-4e4b-8337-ee497c623823",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "scopeParamRequired": false,
+        "composite": false,
+        "clientRole": false,
+        "containerId": "voyager-testing"
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "a6c934e6-f6ca-4e22-96e7-5871b62157d0",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "f5d12726-5cc5-4b90-b82e-6b46cab202ec",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "99da2aac-9eda-4789-afa5-c8806844d32c",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "4e6549db-2717-4538-be44-513fc3c35629",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "scopeParamRequired": false,
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "658bb06a-e6bf-4fb2-8786-792368fce8a7",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "d812c651-541c-4d6e-903e-4124dc2018bf",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "scopeParamRequired": false,
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "manage-authorization",
+                "manage-users",
+                "manage-realm",
+                "view-clients",
+                "view-realm",
+                "view-events",
+                "query-users",
+                "manage-clients",
+                "query-groups",
+                "manage-events",
+                "query-realms",
+                "create-client",
+                "view-identity-providers",
+                "query-clients",
+                "view-users",
+                "manage-identity-providers",
+                "view-authorization",
+                "impersonation"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "7b19f10f-7010-4e75-bd0a-de82960ba890",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "6f371202-4a86-424f-b9bc-2af0ff506f53",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "d1eb2675-f205-4a76-91ec-b6c7ef33ceda",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "e194429f-00f5-48d6-89a5-714d80376075",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "b9dbeaa5-2880-4841-9aff-88775102fe69",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "dd63b251-b1de-49aa-8cf8-e1194eac9026",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "a79915a4-4494-40f7-964c-e22b18481fa1",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "b44ff12a-973c-407b-856f-3e20cddd72e3",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "f84d8600-723a-46c3-a8c1-7cb27ed96dd1",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "7fc16db3-cfdb-4a8e-bffc-eb3ba35f1857",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "scopeParamRequired": false,
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-users",
+                "query-groups"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "f6656971-899c-4a58-842e-b51a6f871095",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "14412176-e687-4d8d-a09b-35ce2c2047fc",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        },
+        {
+          "id": "a7dddf65-1698-4ad4-bcfe-29762ee4a1ae",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418"
+        }
+      ],
+      "security-admin-console": [],
+      "voyager-testing-public": [
+        {
+          "id": "d3e4b174-d5fe-4206-bf32-7566af96e4e3",
+          "name": "uma_protection",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "9e4ad964-80b3-4daf-8917-7801f892ceef"
+        }
+      ],
+      "voyager-testing-bearer": [],
+      "admin-cli": [],
+      "broker": [
+        {
+          "id": "207f4839-3939-442a-821c-1b9c68f3dfd2",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "1b82d46b-2fc6-44f2-8473-9b5557b5809a"
+        }
+      ],
+      "account": [
+        {
+          "id": "cc94bf42-b370-488e-b3c2-3c2664866a39",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "516e481b-27b5-4e24-9960-8fddc3b02f67"
+        },
+        {
+          "id": "315368a3-be6c-4078-b9ae-af35e7dc00b0",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "scopeParamRequired": false,
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "516e481b-27b5-4e24-9960-8fddc3b02f67"
+        },
+        {
+          "id": "53bc8742-154d-472b-9cdb-9b8569588232",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "scopeParamRequired": false,
+          "composite": false,
+          "clientRole": true,
+          "containerId": "516e481b-27b5-4e24-9960-8fddc3b02f67"
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRoles": [
+    "offline_access",
+    "uma_authorization"
+  ],
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpSupportedApplications": [
+    "FreeOTP",
+    "Google Authenticator"
+  ],
+  "clients": [
+    {
+      "id": "7ad54bc9-b548-4341-a265-db41050da56d",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "fa82c025-5d2d-40c8-97ae-842c882b4888",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fa223020-75a5-4a09-99aa-ddf3c4882003",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "id": "c12c208a-aa42-4113-ba75-bd8f7f7a9d7e",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9d39b5ec-e0c4-4a1d-84e6-6b1020787015",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "dbcbc9f4-32d3-496f-a474-01d493c9d7f2",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6555c167-9902-4657-a9fa-9b509e98317e",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    },
+    {
+      "id": "1b82d46b-2fc6-44f2-8473-9b5557b5809a",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "c4261cbb-0df7-4378-ac7f-4e254ce622c6",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8a7a6807-fa77-4026-93d8-287e97e979fe",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "4793d59d-ff1e-4094-8cf1-c8a6f28b46d3",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "09046a29-6203-45a1-8878-3d6dcee2dcaa",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cf3b3dfd-2dc3-4d4d-a146-90090eea54e2",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cf280907-200c-4398-9b14-ed04fb4ae5b3",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    },
+    {
+      "id": "9eee3554-e5e0-432a-ab74-e01474a0c4d7",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "baseUrl": "/auth/admin/voyager-testing/console/index.html",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "/auth/admin/voyager-testing/console/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "c82b3884-b8e9-4554-8bb2-546bcaad5d97",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fc5b3f93-4676-4187-b718-1a7f3f1a33e1",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d68fb42e-1f34-47f4-9a9b-9d123ef698c5",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "id": "b21e076c-30a5-4345-8268-0f68de848b39",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "consentText": "${locale}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "dea03d62-7ec4-4861-9c60-8a451cf03659",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "40783398-84aa-451b-b32e-13c0788ddfe1",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "dfdfeee9-f3d9-4c59-8516-b63896bbbb9e",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    },
+    {
+      "id": "9e4ad964-80b3-4daf-8917-7801f892ceef",
+      "clientId": "voyager-testing-public",
+      "rootUrl": "localhost:8100",
+      "baseUrl": "localhost:8100",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        "http://localhost*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": true,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "f49d18ee-41b2-4cfd-96ca-27c8974b95bc",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "consentText": "",
+          "config": {
+            "user.session.note": "clientId",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientId",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "628f35fd-8590-46f2-a958-55f7d70a4e4f",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "consentText": "",
+          "config": {
+            "user.session.note": "clientHost",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "8b7a3ded-f0ff-4239-a3c0-a4251d89592c",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "consentText": "",
+          "config": {
+            "user.session.note": "clientAddress",
+            "userinfo.token.claim": "true",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9f07acfd-967d-4534-805b-c4dabe52bace",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fd9702c9-60f2-4a26-8941-bf16ca773750",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6fe4582e-4b68-40ac-b349-b1d3b489b9bf",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "82761edb-06fc-43a1-b192-b2ff1a424be6",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "id": "6862b72b-15f9-4554-bd70-e66a4ea780e2",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "ed95097a-a626-4e29-95ef-c363971246cd",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    },
+    {
+      "id": "516e481b-27b5-4e24-9960-8fddc3b02f67",
+      "clientId": "account",
+      "name": "${client_account}",
+      "baseUrl": "/auth/realms/voyager-testing/account",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "defaultRoles": [
+        "manage-account",
+        "view-profile"
+      ],
+      "redirectUris": [
+        "/auth/realms/voyager-testing/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "a4191cd3-d815-41f6-95bf-a7a345a6f55a",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "id": "ceafc8f1-95d0-4b09-b72e-34e0d831fd9c",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "4bfa2704-f9b5-41b5-b25d-82d23c2b203a",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2868efd7-7014-4133-a775-2cf0da867714",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bc40c256-4f60-4df0-8efc-26e50bcf2289",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "45e4d633-d015-4607-b0a8-f3e0941155e9",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    },
+    {
+      "id": "7fa54bed-45f0-49a6-b5f7-d0b02f8f0418",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "930f36ef-e518-4244-96e0-c34271a8c532",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "fc028cbd-6aca-41e8-b83b-ec28f5b97795",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "id": "69293161-0df3-46d7-af41-b762b577dcc8",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6e91c6b4-a39f-4a95-af43-787ddd4776cc",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "fedfdfb2-b4b5-4ffd-bbac-6c7ecfdb384a",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "2c55686d-6ec5-40ed-8ae7-53ebd53a7b6c",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    },
+    {
+      "id": "cceb78c3-d2cf-4c90-b54f-a5dc9e296989",
+      "clientId": "voyager-testing-bearer",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "saml.assertion.signature": "false",
+        "saml.force.post.binding": "false",
+        "saml.multivalued.roles": "false",
+        "saml.encrypt": "false",
+        "saml_force_name_id_format": "false",
+        "saml.client.signature": "false",
+        "saml.authnstatement": "false",
+        "saml.server.signature": "false",
+        "saml.server.signature.keyinfo.ext": "false",
+        "saml.onetimeuse.condition": "false"
+      },
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "protocolMappers": [
+        {
+          "id": "fb56f46c-fa8d-4ca7-99a2-b31a9bfdb429",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${email}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b2b12dc3-8cda-4bc2-8c83-6e0f76a68a44",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${username}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3db002db-3f35-48a8-a1d0-629be7797085",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${givenName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "92321c82-9b8a-4a7f-b4ca-ddcbc0e0ded8",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        },
+        {
+          "id": "f3dcc2c2-3e7a-48c5-95a9-48a4537f512d",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": true,
+          "consentText": "${familyName}",
+          "config": {
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "5aceafdd-0874-48ab-a72d-8e53ba807621",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": true,
+          "consentText": "${fullName}",
+          "config": {
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        }
+      ],
+      "useTemplateConfig": false,
+      "useTemplateScope": false,
+      "useTemplateMappers": false
+    }
+  ],
+  "clientTemplates": [],
+  "browserSecurityHeaders": {
+    "xContentTypeOptions": "nosniff",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "xXSSProtection": "1; mode=block",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "a2c4399b-0db2-498e-bb3c-a7d38548cbde",
+        "name": "Trusted Hosts",
+        "providerId": "trusted-hosts",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "host-sending-registration-request-must-match": [
+            "true"
+          ],
+          "client-uris-must-match": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "8d75a84e-1d02-4b55-b720-178a9a3bf104",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "04cc7bb3-dde9-4885-a386-c5891b9a05b4",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "e01c2496-c4cc-47de-a220-54e9dba9f83e",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "saml-user-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-address-mapper",
+            "oidc-usermodel-property-mapper"
+          ],
+          "consent-required-for-all-mappers": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "0fe7ef3b-ab4a-449d-bfd9-1afcf35406d0",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper",
+            "saml-role-list-mapper",
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-address-mapper"
+          ],
+          "consent-required-for-all-mappers": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "af27b435-28bb-4f3f-87c4-ab934aab1728",
+        "name": "Allowed Client Templates",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "72ee915f-27cd-45d8-9987-0cb145e1df93",
+        "name": "Allowed Client Templates",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "2c62fc95-880f-452d-8ff6-e9df34e77071",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "83b6c41b-05c1-4319-8b07-d94d2a6cfe9a",
+        "name": "hmac-generated",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "c51216c8-1d1c-44c6-930d-ebbae7d0ad8a",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "f331122d-020e-40a3-96e9-94a1c55b36fd",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "supportedLocales": [],
+  "authenticationFlows": [
+    {
+      "id": "fd17dd4e-d972-466d-b950-88ef9aac169b",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "idp-email-verification",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "a99f8598-bc9d-4aba-85c8-340ae9e9be5a",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "OPTIONAL",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "38c96501-91a0-4115-a7e5-966288fca7d0",
+      "alias": "browser",
+      "description": "browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "requirement": "DISABLED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "forms",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "1bd2c823-8f76-468a-9b9b-4fed1d3407b2",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "124eb298-7357-444f-bd11-d6bd1d0a2b5e",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "requirement": "OPTIONAL",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "88b62516-7657-44db-b3e0-ba3d50f4581d",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "3ac16833-4757-4927-b029-0b227cdbd5e1",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "35064aaf-e0c2-448f-a243-d0cdc086f265",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "requirement": "OPTIONAL",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "65edcd16-5d9a-43cd-8f5f-296b6e431584",
+      "alias": "registration",
+      "description": "registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false,
+          "autheticatorFlow": true
+        }
+      ]
+    },
+    {
+      "id": "5cc87186-18a6-4e72-8e35-a170c586294d",
+      "alias": "registration form",
+      "description": "registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-profile-action",
+          "requirement": "REQUIRED",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "requirement": "DISABLED",
+          "priority": 60,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "e8216272-c0c6-48f8-943f-ee2c65b3939e",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-password",
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "requirement": "OPTIONAL",
+          "priority": 40,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    },
+    {
+      "id": "51e3dbd5-91b4-495d-9957-a09b2391b364",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "userSetupAllowed": false,
+          "autheticatorFlow": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "96d091f2-c654-4baa-83f2-bf4db14999d8",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "94c8a3a7-51ad-4c3b-b956-8387c70538a4",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "config": {}
+    },
+    {
+      "alias": "terms_and_conditions",
+      "name": "Terms and Conditions",
+      "providerId": "terms_and_conditions",
+      "enabled": false,
+      "defaultAction": false,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "_browser_header.xXSSProtection": "1; mode=block",
+    "_browser_header.xFrameOptions": "SAMEORIGIN",
+    "_browser_header.strictTransportSecurity": "max-age=31536000; includeSubDomains",
+    "permanentLockout": "false",
+    "quickLoginCheckMilliSeconds": "1000",
+    "_browser_header.xRobotsTag": "none",
+    "maxFailureWaitSeconds": "900",
+    "minimumQuickLoginWaitSeconds": "60",
+    "failureFactor": "30",
+    "actionTokenGeneratedByUserLifespan": "300",
+    "maxDeltaTimeSeconds": "43200",
+    "_browser_header.xContentTypeOptions": "nosniff",
+    "actionTokenGeneratedByAdminLifespan": "43200",
+    "bruteForceProtected": "false",
+    "_browser_header.contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "waitIncrementSeconds": "60"
+  },
+  "keycloakVersion": "3.4.3.Final"
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

This PR makes working locally with keycloak + the showcase app really easy.

* adds a `npm run keycloak` command that starts a keycloak server (using docker-compose)
* adds a `npm run keycloak:init` command that imports a realm, creates roles + users and generates the config needed for the server (`keycloak.json`) and the service config (`mobile-services.json`) for the mobile application.

## Verification Steps

There are steps for setting up the keycloak integration in the readme.

* Follow the steps in the readme to 
  * spin up keycloak
  * run the `keycloak:init` script
  * copy the appropriate configs into the correct location.
* Start the server and the app
* You should be brought to the keycloak login screen
* You can log in with either `developer/developer` or `admin/admin`

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
