### PR TITLE
fix: disable task filtering

### DIFF
--- a/src/app/pages/task/task.page.html
+++ b/src/app/pages/task/task.page.html
@@ -26,11 +26,6 @@
 </ion-toolbar>
 
 <ion-content class="outer-content">
-  <ion-toolbar *ngIf="items" class="searchbar-container">
-    <ion-searchbar [(ngModel)]="searchTerm" (ionChange)="setFilteredItems()" (ionClear)="resetChanges()">
-    </ion-searchbar>
-  </ion-toolbar>
-
   <div [ngSwitch]="selectedSegment">
     <div *ngFor="let case of cases">
       <ion-list *ngSwitchCase="case.case">

--- a/src/app/pages/task/task.page.ts
+++ b/src/app/pages/task/task.page.ts
@@ -19,11 +19,9 @@ export class TaskPage implements OnInit {
 
   item: Task;
   items: Array<Task>;
-  itemsSearchList: Array<Task>;
   online: boolean;
   queue: number;
   errors: any;
-  searchTerm: string;
   cases: { case: string; }[];
   selectedSegment = 'all';
 
@@ -83,7 +81,6 @@ export class TaskPage implements OnInit {
       if (result && !result.errors) {
         console.log('Result from query', result);
         this.items = result.data && result.data.allTasks;
-        this.itemsSearchList = this.items;
       } else {
         console.log('error from query', result);
         this.presentToast('Cannot load data from cache');
@@ -144,15 +141,6 @@ export class TaskPage implements OnInit {
       return false;
     }
     return true;
-  }
-
-  setFilteredItems() {
-    this.resetChanges();
-    this.items = this.itemService.filterItems(this.items, this.searchTerm);
-  }
-
-  resetChanges = () => {
-    this.items = this.itemsSearchList;
   }
 
   async presentToast(message) {

--- a/src/app/services/sync/item.service.ts
+++ b/src/app/services/sync/item.service.ts
@@ -88,15 +88,11 @@ export class ItemService {
     );
   }
 
-  filterItems(items, searchTerm) {
-    return items.filter((item) => {
-      const itemContent = item['title'] + item['description'];
-      return itemContent.toLowerCase().indexOf(searchTerm.toLowerCase()) > -1;
-    });
-  }
-
   getOfflineItems() {
     return this.offlineStore.getOfflineData();
   }
 
+  getClient() {
+    return this.apollo;
+  }
 }


### PR DESCRIPTION
Disable local filtering as it is affecting performance local performance tests and not giving any graphql oriented capability.
Every time new item is added local filter gets triggered that contributes to reduced performance for a really large number of items in offline queue