### PR TITLE
Allow clear text communication also in Android 9 and above

### DIFF
--- a/network_security_config.xml
+++ b/network_security_config.xml
@@ -1,5 +1,5 @@
 <network-security-config>
-  <base-config>
+  <base-config cleartextTrafficPermitted="true">
     <trust-anchors>
       <certificates src="user"/>
       <certificates src="system"/>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Starting with Android 9 clear text communication (http, ws) between the client app and the server is disabled by default.

Most of the user will start the ionic-showcase server locally without any tls certificate (https), and if then they deploy the android app to an android emulator or a real device with android 9 or greater they will have this error in the console `ERR_CLEARTEXT_NOT_PERMITTED`.

I would like to globally enable clear text communication in order to make it more simple to new users to try the ionic-showcase on all devices. 

An alternative solution to this problem is to document in the README how to globally enable clear text [1] or how to do it only for specific domains [2].

1. https://developer.android.com/training/articles/security-config#base-config
2. https://developer.android.com/training/articles/security-config#domain-config

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
