### PR TITLE
Fix android build CircleCI job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,15 +67,13 @@ jobs:
       - restore_cache:
           name: Restoring cordova plugins cache
           keys: 
-            - cordova-plugins-{{ .Branch }}-{{ checksum "config.xml" }}
-            - cordova-plugins-{{ .Branch }}-
-            - cordova-plugins-
+            - cordova-plugins-{{ checksum "config.xml" }}
       - run:
           name: Build android app
           command: npx ionic cordova build android
       - save_cache:
           name: Save cordova plugins cache
-          key: cordova-plugins-{{ .Branch }}-{{ checksum "config.xml" }}
+          key: cordova-plugins-{{ checksum "config.xml" }}
           paths:
             - plugins
       - persist_to_workspace:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: master
+              only: /.*/
       - e2e-android:
           requires:
             - build-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
             tags:
               only: /.*/
             branches:
-              only: /.*/
+              only: master
       - e2e-android:
           requires:
             - build-android

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -99,12 +99,6 @@ jobs:
           key: node-modules-{{ .Branch }}-{{ checksum "package.json" }}
           paths:
             - node_modules
-      - restore_cache:
-          name: Restoring cordova plugins cache
-          keys: 
-            - cordova-plugins-{{ .Branch }}-{{ checksum "config.xml" }}
-            - cordova-plugins-{{ .Branch }}-
-            - cordova-plugins-
       - attach_workspace:
           at: /tmp/workspace
       - run:


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Currently, the build-android job in CireclCI [1] fails because the pipeline restores old Cordova plugins before building the app, and Cordova is not smart enough to delete obsolete plugins from the plugins directory for this reason we should restore plugins from the cache only if the config.xml didn't change from the last build.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
