### PR TITLE
fix: use in memory pubsub when no MQTT_HOST set

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -41,7 +41,7 @@ docker-compose up
 +
 ```shell
 npm install
-npm run start
+npm run dev
 ```
 +
 [NOTE]

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
-    "start": "nodemon src/index.js",
+    "start": "node src/index.js",
+    "dev": "MQTT_HOST=localhost nodemon src/index.js",
     "push": "docker build . -t aerogear/voyager-server-example-task && docker push aerogear/voyager-server-example-task",
     "keycloak": "docker-compose -f ./scripts/keycloak/docker-compose.yml up",
     "keycloak:init": "node ./scripts/keycloak/initKeycloak.js"
@@ -28,9 +29,11 @@
     "knex": "0.19.0",
     "merge-graphql-schemas": "1.5.8",
     "mqtt": "3.0.0",
-    "nodemon": "1.19.1",
     "pg": "7.11.0",
     "shortid": "2.2.14",
     "unifiedpush-node-sender": "0.16.1"
+  },
+  "devDependencies": {
+    "nodemon": "1.19.1"
   }
 }

--- a/server/src/subscriptions.js
+++ b/server/src/subscriptions.js
@@ -1,32 +1,41 @@
-const { PubSub } = require('apollo-server');
+const { PubSub } = require('apollo-server')
 const mqtt = require('mqtt')
 const { MQTTPubSub } = require('@aerogear/graphql-mqtt-subscriptions')
 
-const host = process.env.MQTT_HOST || 'localhost'
+function getPubSub() {
+  const mqttHost = process.env.MQTT_HOST
 
-const mqttOptions = {
-  host: host,
-  servername: host, // needed to work in OpenShift. Lookup SNI.
-  username: process.env.MQTT_USERNAME || '',
-  password: process.env.MQTT_PASSWORD || '' ,
-  port: process.env.MQTT_PORT || '1883',
-  protocol: process.env.MQTT_PROTOCOL || 'mqtt',
-  rejectUnauthorized: false
+  if (mqttHost) {
+    console.log('Using MQTT PubSub')
+    const mqttOptions = {
+      host: mqttHost,
+      servername: mqttHost, // needed to work in OpenShift. Lookup SNI.
+      username: process.env.MQTT_USERNAME || '',
+      password: process.env.MQTT_PASSWORD || '' ,
+      port: process.env.MQTT_PORT || '1883',
+      protocol: process.env.MQTT_PROTOCOL || 'mqtt',
+      rejectUnauthorized: false
+    }
+  
+    const client = mqtt.connect(mqttHost, mqttOptions)
+  
+    console.log(`attempting to connect to messaging service ${mqttHost}`)
+  
+    client.on('connect', () => {
+      console.log('connected to messaging service')
+    })
+  
+    client.on('error', (error) => {
+      console.log('error with mqtt connection')
+      console.log(error)
+    })
+
+    return new MQTTPubSub({ client })
+  }
+  console.log('Using In Memory PubSub')
+  return new PubSub()
 }
 
-const client = mqtt.connect(host, mqttOptions)
-
-console.log(`attempting to connect to messaging service ${host}`)
-
-client.on('connect', () => {
-  console.log('connected to messaging service')
-})
-
-client.on('error', (error) => {
-  console.log('error with mqtt connection')
-  console.log(error)
-})
-
 module.exports = {
-    pubSub: new MQTTPubSub({ client })
+    pubSub: getPubSub()
 }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

* I noticed `npm run start` was using `nodemon`. The showcase container image was running the app using nodemon (not very good)
* I changed `npm run start` to start with node
* I added `npm run dev` to start with `MQTT_HOST=localhost nodemon`
* The server no longer defaults to `localhost` when no `MQTT_HOST` is set. Instead it will default to an in memory pubsub
* While running locally, you can start with `npm start` or `node src/index.js` and by default you will get in memory pubsub
* While running locally, you can start with `npm run dev` or `MQTT_HOST=localhost node src/index.js` to get MQTT Pubsub

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
