### PR TITLE
fix: seed data when cache is empty

### DIFF
--- a/src/app/pages/task/task.page.ts
+++ b/src/app/pages/task/task.page.ts
@@ -75,6 +75,7 @@ export class TaskPage implements OnInit {
     // Refresh cache first
     await this.itemService.refreshItems().catch(() => {
       this.presentToast('Cannot refresh items from server');
+      this.itemService.initCacheIfRequired();
     });
     // Subscribe to local cache changes
     this.itemService.getItems().subscribe(result => {

--- a/src/app/services/sync/item.service.ts
+++ b/src/app/services/sync/item.service.ts
@@ -11,7 +11,6 @@ import {
   ApolloOfflineClient,
   OfflineStore,
   CacheOperation,
-  createMutationOptions,
   subscribeToMoreHelper
 } from '@aerogear/voyager-client';
 import { subscriptionOptions } from './cache.updates';
@@ -54,42 +53,54 @@ export class ItemService {
 
   createItem(title, description) {
     return this.apollo.offlineMutation<Task>({
-        mutation: ADD_TASK,
-        variables: {
-          'title': title,
-          'description': description,
-          'version': 1,
-          'status': 'OPEN'
-        },
-        updateQuery: GET_TASKS,
-        returnType: 'Task'
-      });
+      mutation: ADD_TASK,
+      variables: {
+        'title': title,
+        'description': description,
+        'version': 1,
+        'status': 'OPEN'
+      },
+      updateQuery: GET_TASKS,
+      returnType: 'Task'
+    });
   }
 
   updateItem(item) {
     return this.apollo.offlineMutation<Task>({
-        mutation: UPDATE_TASK,
-        variables: item,
-        updateQuery: GET_TASKS,
-        returnType: 'Task',
-        operationType: CacheOperation.REFRESH
-      }
+      mutation: UPDATE_TASK,
+      variables: item,
+      updateQuery: GET_TASKS,
+      returnType: 'Task',
+      operationType: CacheOperation.REFRESH
+    }
     );
   }
 
   deleteItem(item) {
     return this.apollo.offlineMutation<Task>({
-        mutation: DELETE_TASK,
-        variables: item,
-        updateQuery: GET_TASKS,
-        returnType: 'Task',
-        operationType: CacheOperation.DELETE
-      }
+      mutation: DELETE_TASK,
+      variables: item,
+      updateQuery: GET_TASKS,
+      returnType: 'Task',
+      operationType: CacheOperation.DELETE
+    }
     );
   }
 
   getOfflineItems() {
     return this.offlineStore.getOfflineData();
+  }
+
+  initCacheIfRequired() {
+    // Initialize cache with initial data
+    try {
+      this.apollo.cache.readQuery<AllTasks>({ query: GET_TASKS }, false);
+    } catch (err) {
+      this.apollo.cache.writeQuery({
+        query: GET_TASKS,
+        data: { allTasks: [] }
+      });
+    }
   }
 
   getClient() {


### PR DESCRIPTION
## Motivation

When launching an application for the first time js engine will fail on object creation due to cache not being present. This means that users cannot start without server and go offline to play with the client side features only on the showcase. 

This is very restrictive that is why we are seeding the query with an empty array to make sure that our cache helpers will not fail:

CC @StephenCoady 

Another fix will be to create the same empty array in the cache helper code.

![Screenshot 2019-07-15 at 16 06 19](https://user-images.githubusercontent.com/981838/61226978-5562ba80-a71b-11e9-9fca-87c7448883e5.png)
![Screenshot 2019-07-15 at 16 06 28](https://user-images.githubusercontent.com/981838/61226980-5562ba80-a71b-11e9-9096-5e5c8db20950.png)


## Verification 

1. Start app on incognito
2. No server running
3. Go offline 
4. Try to add new item.


