### PR TITLE
ci: use recommended approach for installing gradle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,16 +39,22 @@ jobs:
     docker:
       - image: circleci/android:api-28-node
     steps:
+      - checkout
+      - run :
+          name: Install SDKMan - a package manager used to install gradle
+          command: curl -s "https://get.sdkman.io" | bash
+      - run:
+          name: Run SDK Man init script (Puts it on the path)
+          command: source ~/.sdkman/bin/sdkman-init.sh
       - run:
           name: Install gradle
-          command: sudo apt install gradle
+          command: sdk install gradle
       - run:
           name: Install ionic
           command: sudo npm --global install ionic
       - run:
           name: Install cordova
           command: sudo npm --global install cordova
-      - checkout
       - restore_cache:
           name: Restore node modules cache
           keys: 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

Gradle's docs recommend using some package manager called SDKman. https://docs.gradle.org/current/userguide/installation.html#installing_with_a_package_manager

My guess is they have started distributing their releases through that and stopped distributing through traditional package managers like `apt`, `dnf` etc.

I verified this PR myself by rerunning the failed build with SSH and performing all the steps manually. This resulted in a successful build.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
