### PR TITLE
ci: fix sdkman installation in android build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,11 +44,8 @@ jobs:
           name: Install SDKMan - a package manager used to install gradle
           command: curl -s "https://get.sdkman.io" | bash
       - run:
-          name: Run SDK Man init script (Puts it on the path)
-          command: source ~/.sdkman/bin/sdkman-init.sh
-      - run:
-          name: Install gradle
-          command: sdk install gradle
+          name: Run SDK Man init script and install gradle
+          command: source ~/.sdkman/bin/sdkman-init.sh && sdk install gradle
       - run:
           name: Install ionic
           command: sudo npm --global install ionic


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

It turns out CircleCI runs each command in its own sandbox so we need to run these sdkman related commands together.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
