### PR TITLE
fix: wait for auth to be initialised

### DIFF
--- a/src/app/services/sync/voyager.service.ts
+++ b/src/app/services/sync/voyager.service.ts
@@ -73,7 +73,7 @@ export class VoyagerService {
       options.openShiftConfig = this.openShift.getConfig();
     }
     const authService = this.injector.get(AuthService);
-    if (authService.isEnabled()) {
+    if (authService.isEnabled() && await authService.initialized) {
       options.authContextProvider = authService.getAuthContextProvider();
     }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

@jhellar I think this fixes the bug you found in the showcase. It was a race condition between keycloak being initialised over the network and the apollo client being created and firing offline mutations too quickly.

Do you think you could try this out for me on a device and see if it works? I have checked against the cluster you gave me yesterday and I can't reproduce the bug with this fix.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
