### PR TITLE
Isnotcordova

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "@aerogear/cordova-plugin-aerogear-metrics": "2.6.0",
     "@aerogear/cordova-plugin-iroot": "0.8.1",
     "@aerogear/push": "2.6.0",
-    "@aerogear/security": "2.6.0",
+    "@aerogear/security": "2.6.1-dev.1",
     "@aerogear/voyager-client": "2.6.0",
     "@angular/common": "7.2.12",
     "@angular/core": "7.2.12",

--- a/src/app/pages/apptrust/apptrust.page.html
+++ b/src/app/pages/apptrust/apptrust.page.html
@@ -11,6 +11,20 @@
 </ion-header>
 
 <ion-content>
+  <!-- if not using cordova -->
+  <ion-card *ngIf="isNotMobileCordova()">
+    <ion-card-header>
+      <ion-card-title>Application Trust disabled </ion-card-title>
+      <ion-card-subtitle>Application Trust checks are available only on iOS or Android devices.</ion-card-subtitle>
+    </ion-card-header>
+
+    <ion-card-content>
+      <ion-icon color="warning" name="warning"></ion-icon>
+      Application Trust page cannot be displayed.
+      Application Trust checks are available only on iOS or Android devices.
+    </ion-card-content>
+  </ion-card>
+
   <!-- Application Trust is disabled -->
   <ion-card *ngIf="isDisabled()">
     <ion-card-header>
@@ -25,7 +39,7 @@
     </ion-card-content>
   </ion-card>
 
-  <ion-card *ngIf="!isDisabled()">
+  <ion-card *ngIf="!isDisabled() && !isNotMobileCordova()">
     <ion-card-header>
       <ion-card-title>Application Security Status </ion-card-title>
     </ion-card-header>
@@ -45,7 +59,7 @@
     </ion-card-content>
   </ion-card>
 
-  <ion-card *ngIf="!isDisabled()">
+  <ion-card *ngIf="!isDisabled() && !isNotMobileCordova()">
     <ion-card-header>
       <ion-card-title>Steps to Disable/Enable App Version</ion-card-title>
     </ion-card-header>

--- a/src/app/pages/apptrust/apptrust.page.ts
+++ b/src/app/pages/apptrust/apptrust.page.ts
@@ -1,6 +1,7 @@
 import {Component, OnInit} from '@angular/core';
 import { AlertController } from '@ionic/angular';
 import { SecurityService } from '../../services/security.service';
+import { isMobileCordova } from '@aerogear/core';
 
 
 declare var navigator: any;
@@ -24,6 +25,9 @@ export class AppTrustPage {
 
   public isDisabled() {
     return !this.securityService.isEnabled();
+  }
+  public isNotMobileCordova() {
+    return !isMobileCordova();
   }
 
   public clientInit() {


### PR DESCRIPTION
## Description
fix for https://issues.jboss.org/browse/AGMS-662

## Verification 

- clone the ionic-showcase https://github.com/aerogear/ionic-showcase
- checkout this branch 

- change the mobile-services.json to 
```json
{
  "version": 1,
  "namespace": "voyager",
  "clientId": "voyager-ionic-example",
  "services": [
    {
    "id": "security",
    "name": "security",
    "type": "security",
    "url": "https://route-mobile-security-service.apps.mdsdemo-710a.openshiftworkshop.com/"
  }
]
}

```
- install
```bash
npm i
npm run start
````
- check that the warning is displayed in the web
![image](https://user-images.githubusercontent.com/16667688/62544648-1aeec800-b858-11e9-8da5-d77ddf0341e2.png)


- run an android build 
```bash
ionic cordova build android
```
- copy the apk file to an android emulator 
- Check to see if the app trust page loads as expected

![aerogear-demo](https://user-images.githubusercontent.com/16667688/56582990-7611ed00-65d0-11e9-8e60-23d7692c9c56.gif)

