### PR TITLE
Manifest keycloak invalid configuration in UI and console

### DIFF
--- a/src/app/pages/profile/profile.page.ts
+++ b/src/app/pages/profile/profile.page.ts
@@ -1,5 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 import { AuthService } from '../../services/auth.service';
+import { AlertController } from '@ionic/angular';
 
 @Component({
   selector: 'app-profile',
@@ -9,7 +10,7 @@ import { AuthService } from '../../services/auth.service';
 export class ProfilePage implements OnInit {
   profile: any;
 
-  constructor(private authService: AuthService) {
+  constructor(private authService: AuthService, public alertCtrl: AlertController) {
   }
 
   ngOnInit() {
@@ -26,12 +27,16 @@ export class ProfilePage implements OnInit {
   login() {
     this.authService.login().then(() => {
       this.loadUserProfile();
+    }).catch((err) => {
+      console.warn('Login failed', err);
     });
   }
 
   logout() {
     this.authService.logout().then(() => {
       this.profile = undefined;
+    }).catch((err) => {
+      console.warn('Login failed', err);
     });
   }
 
@@ -49,8 +54,16 @@ export class ProfilePage implements OnInit {
         emailVerified: userProfile.emailVerified ? userProfile.emailVerified : false,
         realmRoles,
       };
-    })
-      .catch((err) => console.error('Error retrieving user profile', err));
+    }).catch((err) => {
+      this.alertCtrl.create({
+        message: `Cannot retrieve profile. Please review application configuration.`,
+        header: `Login failed`,
+        buttons: ['OK']
+      }).then((dialog) => {
+        dialog.present();
+      }).catch(() => { });
+      console.error('Error retrieving user profile', err);
+    });
   }
 
   public ionViewDidEnter(): void {

--- a/src/app/pages/profile/profile.page.ts
+++ b/src/app/pages/profile/profile.page.ts
@@ -56,7 +56,7 @@ export class ProfilePage implements OnInit {
       };
     }).catch((err) => {
       this.alertCtrl.create({
-        message: `Cannot retrieve profile. Please review application configuration.`,
+        message: `Cannot retrieve profile. Please review keycloak client configuration.`,
         header: `Login failed`,
         buttons: ['OK']
       }).then((dialog) => {

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -24,6 +24,11 @@ export class AuthService {
             this.initialized = platform.ready().then(() => {
                 const initOptions: KeycloakInitOptions = { onLoad: 'login-required' };
                 return this.auth.init(initOptions);
+            }).catch((error) => {
+                console.warn(`Failed to intialize keycloak
+Please review your keycloak client configuration on keycloak server
+and check if you have setup proper "Valid Redirect URIs" and "Web Origins" values`);
+                return false;
             });
         }
     }


### PR DESCRIPTION
## Target 

Our mobile config requires setting up valid redirect urls and web orgins. 
Without that application will not work properly.
Without this change, showcase was failing miserably with the white screen if keycloak was initialized with wrong values.

After this change devs are notified in the console:

![Screenshot 2019-08-07 at 11 52 48](https://user-images.githubusercontent.com/981838/62617756-7d080580-b90a-11e9-8d49-f4a10e3bae26.png)

and UI: 

![Screenshot 2019-08-07 at 11 54 26](https://user-images.githubusercontent.com/981838/62617760-81342300-b90a-11e9-9fa8-a7a8175c9d05.png)
