### PR TITLE
fix: explicitly enable introspection

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -51,6 +51,7 @@ async function start() {
     typeDefs: appTypeDefs,
     resolvers: appResolvers,
     playground: config.playgroundConfig,
+    introspection: true,
     context: async ({
       req
     }) => {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Right now I'm working on this issue: https://issues.jboss.org/browse/AEROGEAR-9693

As part of that I'm moving the showcase openshift template towards using an official Red Hat Node.js image. This image explicitly sets NODE_ENV=production which disables introspection.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
