### PR TITLE
Fix E2E flaky tests

### DIFF
--- a/e2e/protractor.conf.js
+++ b/e2e/protractor.conf.js
@@ -5,7 +5,7 @@ const { SpecReporter } = require('jasmine-spec-reporter');
 
 exports.config = {
   seleniumAddress: 'http://hub.browserstack.com/wd/hub',
-  allScriptsTimeout: 11000,
+  allScriptsTimeout: 30000,
   specs: [
     './src/**/*.e2e-spec.ts'
   ],
@@ -17,6 +17,8 @@ exports.config = {
     autoWebview: true,
     'browserstack.user': process.env.BROWSERSTACK_USER,
     'browserstack.key': process.env.BROWSERSTACK_KEY,
+    'browserstack.debug': true,
+    'browserstack.networkLogs': true,
   },
   framework: 'jasmine',
   jasmineNodeOpts: {

--- a/e2e/src/app.e2e-spec.ts
+++ b/e2e/src/app.e2e-spec.ts
@@ -1,6 +1,13 @@
-import { element, by } from 'protractor';
+import { element, by, browser } from 'protractor';
 
 describe('App', () => {
+  beforeAll(async () => {
+    // Sometimes protractor is faster than angular.
+    // By making Appium sleep for 1s before injecting protractor
+    // we ensure that angular get loaded correctly.
+    await browser.sleep(1000);
+  });
+
   it('AeroGear logo should be visible', () => {
     expect(element(by.css('ion-img.logo')).isDisplayed()).toBeTruthy();
   });


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

When running the e2e tests in a loop forever they usually fail after ~10 executions because protractor is injected before angular is loaded.

By sleep 1s before starting all tests we give time to Angular to load correctly. 1s is enough time for Angular to set the `window.angular` variable and then protractor will take care of waiting for all angular services to be loaded.

In order to ensure that 1s is enough I've executed again all tests in loop for more the 2h ( ~100 executions ) without having any issues

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] `npm test` passes
- [x] `npm run build` works
- [x] tests are included
- [x] documentation is changed or added
