### PR TITLE
fix ionic version

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "@types/jasminewd2": "2.0.6",
     "@types/node": "10.14.15",
     "codelyzer": "5.1.0",
-    "ionic": "^5.3.0",
+    "ionic": "^4.12.0",
     "jasmine-core": "3.4.0",
     "jasmine-spec-reporter": "4.2.1",
     "karma": "4.2.0",


### PR DESCRIPTION
## Description

In README it is recommended to install ionic version 4, but in package.json there is ionic@5. For me this broke `npm run ionic:android`:

```
➜  ionic-showcase git:(master) npm run ionic:android

> ionic4-graphql-starter-app@1.0.0 ionic:android /Users/jhellar/work/repos/ionic-showcase
> ionic cordova run android

[ERROR] native-run was not found on your PATH. Please install it globally:

        npm i -g native-run

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! ionic4-graphql-starter-app@1.0.0 ionic:android: `ionic cordova run android`
npm ERR! Exit status 1
npm ERR!
npm ERR! Failed at the ionic4-graphql-starter-app@1.0.0 ionic:android script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/jhellar/.npm/_logs/2019-09-24T13_50_34_856Z-debug.log
```

Changing to version 4 fixes the build.
