### PR TITLE
fix: stop using docker layer caching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,6 @@ jobs:
       # special workaround to allow running docker in docker https://circleci.com/docs/2.0/building-docker-images/
       - setup_remote_docker:
           version: 17.05.0-ce
-          docker_layer_caching: true
       - run: |
           cd server          
           TAG=$CIRCLE_TAG ../scripts/publish_example_server_container.sh


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

Apparently this feature is now a paid feature and it's causing jobs on master to fail.

https://circleci.com/gh/aerogear/ionic-showcase/1557?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-build-link

Removing it to see will those jobs start passing again.

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
