### PR TITLE
fix: Build server and client

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
             - ./node_modules
       - run:
           name: run build
-          command: "cd client && npm run build"
+          command: "yarn build"
 
   publish_showcase_container:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,18 +6,16 @@ jobs:
       - image: circleci/node:lts
     steps:
       - checkout
-      - run:
-          name: update-npm
-          command: "sudo npm install -g npm@latest"
       - restore_cache:
-          key: dependency-cache-{{ checksum "client/package.json" }}
+          key: dependency-cache-{{ checksum "client/package.json" }}-{{checksum "server/package.json"}}
       - run:
           name: install-dependencies
-          command: "cd client && npm install"
+          command: yarn
+      - run:
+          name: install-package-dependencies
+          command: yarn
       - save_cache:
-          key: dependency-cache-{{ checksum "client/package.json" }}
-          paths:
-            - ./client/node_modules
+          key: dependency-cache-{{ checksum "client/package.json" }}-{{checksum "server/package.json"}}
       - run:
           name: run build
           command: "cd client && npm run build"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,8 +32,8 @@ jobs:
       - setup_remote_docker:
           version: 17.05.0-ce
       - run: | 
-          npm i
-          npm run build:prod
+          yarn
+          cd client && yarn build:prod
       - run: |
           cd server          
           TAG=$CIRCLE_TAG ../scripts/publish_showcase_container.sh

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,8 @@ jobs:
           command: yarn
       - save_cache:
           key: dependency-cache-{{ checksum "client/package.json" }}-{{checksum "server/package.json"}}
+          paths:
+            - ./node_modules
       - run:
           name: run build
           command: "cd client && npm run build"

--- a/package.json
+++ b/package.json
@@ -1,20 +1,23 @@
 {
-  "name": "showcase-monorepository",
+  "name": "showcase",
   "version": "1.0.0",
   "private": true,
   "description": "Mono repository for Ionic Showcase",
   "main": "index.js",
   "devDependencies": {
+    "del-cli": "3.0.0"
   },
   "scripts": {
     "start:server": "cd server/ && yarn start",
     "start:client": "cd client/ && yarn start",
     "build:server": "cd server/ && yarn build",
     "build:client": "cd client/ && yarn build",
-    "build": "cd server/ && yarn build && cd client/ && yarn build"
+    "build": "yarn workspaces run build",
+    "unlock": "yarn workspaces run del package-lock.json && del yarn.lock",
+    "clean": "yarn workspaces run del ./dist && del ./types"
   },
   "workspaces": [
-    "client/*",
-    "server/**"
+    "client",
+    "server"
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,10 @@
   },
   "scripts": {
     "start:server": "cd server/ && yarn start",
-    "start:client": "cd client/ && yarn start"
+    "start:client": "cd client/ && yarn start",
+    "build:server": "cd server/ && yarn build",
+    "build:client": "cd client/ && yarn build",
+    "build": "cd server/ && yarn build && cd client/ && yarn build"
   },
   "workspaces": [
     "client/*",

--- a/server/package.json
+++ b/server/package.json
@@ -4,6 +4,7 @@
   "description": "",
   "main": "src/index.js",
   "scripts": {
+    "build": "echo 'ts-ignore ;)'",
     "start": "node src/index.js",
     "dev": "MQTT_HOST=localhost nodemon src/index.js",
     "push": "docker build . -t aerogear/voyager-server-example-task && docker push aerogear/voyager-server-example-task",


### PR DESCRIPTION
Early test to check circleci.
Generally graphback will have server in typescript so current build is disabled for that purpose. 
I wanted to do piping first