### PR TITLE
fix: add ability to define server url at build time

### DIFF
--- a/client/src/config/clientConfig.ts
+++ b/client/src/config/clientConfig.ts
@@ -7,13 +7,23 @@ import { InMemoryCache } from 'apollo-cache-inmemory';
 import { globalCacheUpdates, ConflictLogger } from '../helpers';
 import { getAuthHeader } from '../auth/keycloakAuth';
 
+const httpUri = process.env.REACT_APP_SERVER_URL || 'http://localhost:4000/graphql';
+const httpsEnabled = httpUri.startsWith('https://')
+const httpEnabled = httpUri.startsWith('http://')
+
+if (!httpsEnabled && !httpsEnabled) {
+  throw new Error(`invalid server url ${httpUri} must begin with https:// or http://`)
+}
+
+const wsUri = httpsEnabled ? httpUri.replace('https://', 'wss://') : httpUri.replace('http://', 'ws://')
+
 /**
  * Create websocket link and
  * define websocket link options
  * 
  */
 const wsLink = new WebSocketLink({
-  uri: 'ws://localhost:4000/graphql',
+  uri: wsUri,
   options: {
     reconnect: true,
     lazy: true,
@@ -23,7 +33,7 @@ const wsLink = new WebSocketLink({
 });
 
 const httpLink = new HttpLink({
-  uri: 'http://localhost:4000/graphql',
+  uri: httpUri,
 });
 
 /**

--- a/client/src/config/clientConfig.ts
+++ b/client/src/config/clientConfig.ts
@@ -11,7 +11,7 @@ const httpUri = process.env.REACT_APP_SERVER_URL || 'http://localhost:4000/graph
 const httpsEnabled = httpUri.startsWith('https://')
 const httpEnabled = httpUri.startsWith('http://')
 
-if (!httpsEnabled && !httpsEnabled) {
+if (!httpEnabled && !httpsEnabled) {
   throw new Error(`invalid server url ${httpUri} must begin with https:// or http://`)
 }
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.
-->

### Description

This PR makes it possible to point the client app to a given server url (specified at build time)

Examples of how this works with our current npm scripts

```
REACT_APP_SERVER_URL=https://some-domain.com/graphql yarn start
```

or

```
REACT_APP_SERVER_URL=https://some-domain.com/graphql yarn build
```

There's a little bit of cleverness there to set the websocket url based on the http url provided also. This is a pretty canonical way to do this in react applications over static config files that are being checked into the repo. See https://create-react-app.dev/docs/adding-custom-environment-variables/

<!-- Please provide a description of your pull request and any relevant steps needed to verify it -->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] `npm test` passes
- [ ] `npm run build` works
- [ ] tests are included
- [ ] documentation is changed or added
